### PR TITLE
OLISYS-4403 | update new all libraries in all the APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.my-oli</groupId>
     <artifactId>banula-open-library</artifactId>
-    <version>0.1.3</version>
+    <version>0.1.4-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>banula-open-library</name>

--- a/src/main/java/com/banula/openlib/ocpi/custom/smartlocations/DefaultSupplier.java
+++ b/src/main/java/com/banula/openlib/ocpi/custom/smartlocations/DefaultSupplier.java
@@ -1,0 +1,26 @@
+package com.banula.openlib.ocpi.custom.smartlocations;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotEmpty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class DefaultSupplier {
+    @JsonProperty("supplier_market_partner_id")
+    @NotEmpty(message = "Supplier market partner ID cannot be empty")
+    private String supplierMarketPartnerId;
+
+    @JsonProperty("bkv_id")
+    @NotEmpty(message = "BKV ID cannot be empty")
+    private String bkvId;
+
+    @JsonProperty("balancing_group_eic_id")
+    @NotEmpty(message = "Balancing group EIC ID cannot be empty")
+    private String balancingGroupEicId;
+}

--- a/src/main/java/com/banula/openlib/ocpi/custom/smartlocations/MeteringDataSource.java
+++ b/src/main/java/com/banula/openlib/ocpi/custom/smartlocations/MeteringDataSource.java
@@ -1,0 +1,14 @@
+package com.banula.openlib.ocpi.custom.smartlocations;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public enum MeteringDataSource {
+    @JsonProperty("MSCONS")
+    MSCONS,
+
+    @JsonProperty("SMART_METER")
+    SMART_METER,
+
+    @JsonProperty("CONTROL_BACKEND")
+    CONTROL_BACKEND
+}

--- a/src/main/java/com/banula/openlib/ocpi/custom/smartlocations/SmartLocation.java
+++ b/src/main/java/com/banula/openlib/ocpi/custom/smartlocations/SmartLocation.java
@@ -3,29 +3,53 @@ package com.banula.openlib.ocpi.custom.smartlocations;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.banula.openlib.ocpi.model.Location;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
-@SuperBuilder
 @Data
+@EqualsAndHashCode(callSuper = true)
 @AllArgsConstructor
 @NoArgsConstructor
+@SuperBuilder
 public class SmartLocation extends Location {
-    @JsonProperty("default_supplier")
-    @NotEmpty(message = "Default supplier cannot be empty")
-    private String defaultSupplier;
+    @JsonProperty("market_location_id")
+    @NotEmpty(message = "Marktlokation-ID cannot be empty")
+    private String marketLocationId;
+
+    @JsonProperty("metering_location_id")
+    @NotEmpty(message = "Messlokation-ID cannot be empty")
+    private String meteringLocationId;
+
+    @JsonProperty("dso_market_partner_id")
+    @NotEmpty(message = "Verteilnetzbetreiber Partner-ID cannot be empty")
+    private String dsoMarketPartnerId;
+
+    @JsonProperty("tso_market_partner_id")
+    @NotEmpty(message = "Übertragungsnetzbetreiber Partner-ID cannot be empty")
+    private String tsoMarketPartnerId;
+
+    @JsonProperty("mpo_market_partner_id")
+    @NotEmpty(message = "Messstellenbetreiber Partner-ID cannot be empty")
+    private String mpoMarketPartnerId;
+
+    @JsonProperty("metering_data_source")
+    @NotNull(message = "Metering data source cannot be null")
+    private MeteringDataSource meteringDataSource;
 
     @JsonProperty("malo")
-    @NotEmpty(message = "Malo cannot be empty")
     private String malo;
 
     @JsonProperty("smart_meter_id")
-    @NotEmpty(message = "Smart meter ID cannot be empty")
     private String smartMeterId;
 
     @JsonProperty("message_queue_url")
-    @NotEmpty(message = "Message queue URL cannot be empty")
     private String messageQueueUrl;
+
+    @JsonProperty("default_supplier")
+    @NotNull(message = "Default supplier cannot be null")
+    private DefaultSupplier defaultSupplier;
 }

--- a/src/main/java/com/banula/openlib/ocpi/custom/smartlocations/dto/SmartLocationDTO.java
+++ b/src/main/java/com/banula/openlib/ocpi/custom/smartlocations/dto/SmartLocationDTO.java
@@ -1,32 +1,62 @@
 package com.banula.openlib.ocpi.custom.smartlocations.dto;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
+import com.banula.openlib.ocpi.custom.smartlocations.DefaultSupplier;
+import com.banula.openlib.ocpi.custom.smartlocations.MeteringDataSource;
 import com.banula.openlib.ocpi.custom.smartlocations.validations.SmartLocationCreateGroup;
 import com.banula.openlib.ocpi.model.dto.LocationDTO;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.EqualsAndHashCode;
 import lombok.NoArgsConstructor;
 import lombok.experimental.SuperBuilder;
 
 @Data
+@EqualsAndHashCode(callSuper = true)
 @AllArgsConstructor
 @NoArgsConstructor
 @SuperBuilder
 public class SmartLocationDTO extends LocationDTO {
-    @JsonProperty("default_supplier")
-    @NotEmpty(message = "Default supplier cannot be empty", groups = SmartLocationCreateGroup.class)
-    private String defaultSupplier;
+    @JsonProperty("market_location_id")
+    @NotEmpty(message = "Marktlokation-ID cannot be empty", groups = SmartLocationCreateGroup.class)
+    private String marketLocationId;
+
+    @JsonProperty("metering_location_id")
+    @NotEmpty(message = "Messlokation-ID cannot be empty", groups = SmartLocationCreateGroup.class)
+    private String meteringLocationId;
+
+    @JsonProperty("dso_market_partner_id")
+    @NotEmpty(message = "Verteilnetzbetreiber Partner-ID cannot be empty", groups = SmartLocationCreateGroup.class)
+    private String dsoMarketPartnerId;
+
+    @JsonProperty("tso_market_partner_id")
+    @NotEmpty(message = "Übertragungsnetzbetreiber Partner-ID cannot be empty", groups = SmartLocationCreateGroup.class)
+    private String tsoMarketPartnerId;
+
+    @JsonProperty("mpo_market_partner_id")
+    @NotEmpty(message = "Messstellenbetreiber Partner-ID cannot be empty", groups = SmartLocationCreateGroup.class)
+    private String mpoMarketPartnerId;
+
+    @JsonProperty("metering_data_source")
+    @NotNull(message = "Metering data source cannot be null", groups = SmartLocationCreateGroup.class)
+    private MeteringDataSource meteringDataSource;
 
     @JsonProperty("malo")
     @NotEmpty(message = "Malo cannot be empty", groups = SmartLocationCreateGroup.class)
     private String malo;
 
     @JsonProperty("smart_meter_id")
-    @NotEmpty(message = "Smart meter ID cannot be empty", groups = SmartLocationCreateGroup.class)
     private String smartMeterId;
 
     @JsonProperty("message_queue_url")
-    @NotEmpty(message = "Message queue URL cannot be empty", groups = SmartLocationCreateGroup.class)
     private String messageQueueUrl;
+
+    @Valid
+    @JsonProperty("default_supplier")
+    @NotNull(message = "Default supplier cannot be null", groups = SmartLocationCreateGroup.class)
+    private DefaultSupplier defaultSupplier;
 }

--- a/src/main/java/com/banula/openlib/ocpi/custom/smartlocations/mapper/SmartLocationMapper.java
+++ b/src/main/java/com/banula/openlib/ocpi/custom/smartlocations/mapper/SmartLocationMapper.java
@@ -1,0 +1,122 @@
+package com.banula.openlib.ocpi.custom.smartlocations.mapper;
+
+import com.banula.openlib.ocpi.custom.smartlocations.SmartLocation;
+import com.banula.openlib.ocpi.custom.smartlocations.dto.SmartLocationDTO;
+import com.banula.openlib.ocpi.model.dto.GeoLocationDTO;
+import com.banula.openlib.ocpi.model.vo.GeoLocation;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public class SmartLocationMapper {
+
+    public static SmartLocation toSmartLocationEntity(SmartLocationDTO smartLocationDTO) {
+
+        if (smartLocationDTO == null)
+            return null;
+
+        GeoLocation geoLocation = smartLocationDTO.getCoordinates() == null
+                ? null
+                : new GeoLocation(Double.parseDouble(smartLocationDTO.getCoordinates().getLatitude()),
+                        Double.parseDouble(smartLocationDTO.getCoordinates().getLongitude()));
+
+        return SmartLocation.builder()
+                .id(smartLocationDTO.getId())
+                .city(smartLocationDTO.getCity())
+                .address(smartLocationDTO.getAddress())
+                .evses(smartLocationDTO.getEvses())
+                .coordinates(geoLocation)
+                .energyMix(smartLocationDTO.getEnergyMix())
+                .name(smartLocationDTO.getName())
+                .countryCode(smartLocationDTO.getCountryCode())
+                .country(smartLocationDTO.getCountry())
+                .lastUpdated(smartLocationDTO.getLastUpdated())
+                .owner(smartLocationDTO.getOwner())
+                .relatedLocations(smartLocationDTO.getRelatedLocations())
+                .directions(smartLocationDTO.getDirections())
+                .images(smartLocationDTO.getImages())
+                .facilities(smartLocationDTO.getFacilities())
+                .openingTimes(smartLocationDTO.getOpeningTimes())
+                .operator(smartLocationDTO.getOperator())
+                .state(smartLocationDTO.getState())
+                .parkingType(smartLocationDTO.getParkingType())
+                .publish(smartLocationDTO.getPublish())
+                .postalCode(smartLocationDTO.getPostalCode())
+                .partyId(smartLocationDTO.getPartyId())
+                .publishAllowedTo(smartLocationDTO.getPublishAllowedTo())
+                .subOperator(smartLocationDTO.getSubOperator())
+                .timeZone(smartLocationDTO.getTimeZone())
+                .chargingWhenClosed(smartLocationDTO.getChargingWhenClosed())
+                // Smart Location Fields
+                .defaultSupplier(smartLocationDTO.getDefaultSupplier())
+                .malo(smartLocationDTO.getMalo())
+                .smartMeterId(smartLocationDTO.getSmartMeterId())
+                .messageQueueUrl(smartLocationDTO.getMessageQueueUrl())
+                .build();
+    }
+
+    public static SmartLocationDTO toSmartLocationDTO(SmartLocation location) {
+        if (location == null)
+            return null;
+
+        GeoLocationDTO geoLocationDTO = location.getCoordinates() == null ? null
+                : location.getCoordinates().getCoordinates() == null ? null
+                        : new GeoLocationDTO(location.getCoordinates().getCoordinates().get(0),
+                                location.getCoordinates().getCoordinates().get(1));
+
+        return SmartLocationDTO.builder()
+                .id(location.getId())
+                .city(location.getCity())
+                .address(location.getAddress())
+                .evses(location.getEvses())
+                .coordinates(geoLocationDTO)
+                .energyMix(location.getEnergyMix())
+                .name(location.getName())
+                .countryCode(location.getCountryCode())
+                .country(location.getCountry())
+                .lastUpdated(location.getLastUpdated())
+                .owner(location.getOwner())
+                .relatedLocations(location.getRelatedLocations())
+                .directions(location.getDirections())
+                .images(location.getImages())
+                .facilities(location.getFacilities())
+                .openingTimes(location.getOpeningTimes())
+                .operator(location.getOperator())
+                .state(location.getState())
+                .parkingType(location.getParkingType())
+                .publish(location.getPublish())
+                .postalCode(location.getPostalCode())
+                .partyId(location.getPartyId())
+                .publishAllowedTo(location.getPublishAllowedTo())
+                .subOperator(location.getSubOperator())
+                .timeZone(location.getTimeZone())
+                .chargingWhenClosed(location.getChargingWhenClosed())
+                // Smart Location Fields
+                .defaultSupplier(location.getDefaultSupplier())
+                .malo(location.getMalo())
+                .smartMeterId(location.getSmartMeterId())
+                .messageQueueUrl(location.getMessageQueueUrl())
+                .build();
+    }
+
+    public static List<SmartLocationDTO> toListSmartLocationDTO(List<SmartLocation> entities) {
+        if (entities == null) {
+            return null;
+        }
+        return entities.stream()
+                .filter(Objects::nonNull)
+                .map(SmartLocationMapper::toSmartLocationDTO)
+                .collect(Collectors.toList());
+    }
+
+    public static List<SmartLocation> toListSmartLocation(List<SmartLocationDTO> dtos) {
+        if (dtos == null) {
+            return null;
+        }
+        return dtos.stream()
+                .filter(Objects::nonNull)
+                .map(SmartLocationMapper::toSmartLocationEntity)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/banula/openlib/ocpi/mapper/ChargingSessionMapper.java
+++ b/src/main/java/com/banula/openlib/ocpi/mapper/ChargingSessionMapper.java
@@ -1,0 +1,59 @@
+package com.banula.openlib.ocpi.mapper;
+
+import com.banula.openlib.ocpi.model.ChargingSession;
+import com.banula.openlib.ocpi.model.dto.ChargingSessionDTO;
+
+public class ChargingSessionMapper {
+
+    public static ChargingSession toChargingSessionEntity(ChargingSessionDTO sessionDTO) {
+        if (sessionDTO == null)
+            return null;
+        return ChargingSession.builder()
+                .chargingPeriods(sessionDTO.getChargingPeriods())
+                .id(sessionDTO.getId())
+                .authMethod(sessionDTO.getAuthMethod())
+                .currency(sessionDTO.getCurrency())
+                .kwh(sessionDTO.getKwh())
+                .cdrToken(sessionDTO.getCdrToken())
+                .connectorId(sessionDTO.getConnectorId())
+                .evseUid(sessionDTO.getEvseUid())
+                .authorizationReference(sessionDTO.getAuthorizationReference())
+                .countryCode(sessionDTO.getCountryCode())
+                .endDateTime(sessionDTO.getEndDateTime())
+                .startDateTime(sessionDTO.getStartDateTime())
+                .lastUpdated(sessionDTO.getLastUpdated())
+                .meterId(sessionDTO.getMeterId())
+                .locationId(sessionDTO.getLocationId())
+                .partyId(sessionDTO.getPartyId())
+                .status(sessionDTO.getStatus())
+                .totalCost(sessionDTO.getTotalCost())
+                .authMethod(sessionDTO.getAuthMethod())
+                .build();
+    }
+
+    public static ChargingSessionDTO toChargingSessionDTO(ChargingSession chargingSession) {
+        if (chargingSession == null)
+            return null;
+        return ChargingSessionDTO.builder()
+                .chargingPeriods(chargingSession.getChargingPeriods())
+                .id(chargingSession.getId())
+                .authMethod(chargingSession.getAuthMethod())
+                .currency(chargingSession.getCurrency())
+                .kwh(chargingSession.getKwh())
+                .cdrToken(chargingSession.getCdrToken())
+                .connectorId(chargingSession.getConnectorId())
+                .evseUid(chargingSession.getEvseUid())
+                .authorizationReference(chargingSession.getAuthorizationReference())
+                .countryCode(chargingSession.getCountryCode())
+                .endDateTime(chargingSession.getEndDateTime())
+                .startDateTime(chargingSession.getStartDateTime())
+                .lastUpdated(chargingSession.getLastUpdated())
+                .meterId(chargingSession.getMeterId())
+                .locationId(chargingSession.getLocationId())
+                .partyId(chargingSession.getPartyId())
+                .status(chargingSession.getStatus())
+                .totalCost(chargingSession.getTotalCost())
+                .authMethod(chargingSession.getAuthMethod())
+                .build();
+    }
+}

--- a/src/main/java/com/banula/openlib/ocpi/mapper/ChargingSessionMapper.java
+++ b/src/main/java/com/banula/openlib/ocpi/mapper/ChargingSessionMapper.java
@@ -27,7 +27,6 @@ public class ChargingSessionMapper {
                 .partyId(sessionDTO.getPartyId())
                 .status(sessionDTO.getStatus())
                 .totalCost(sessionDTO.getTotalCost())
-                .authMethod(sessionDTO.getAuthMethod())
                 .build();
     }
 

--- a/src/main/java/com/banula/openlib/ocpi/model/dto/ChargingSessionDTO.java
+++ b/src/main/java/com/banula/openlib/ocpi/model/dto/ChargingSessionDTO.java
@@ -86,6 +86,7 @@ public class ChargingSessionDTO {
     @NotNull
     @JsonProperty("status")
     private SessionStatus status;
+
     @NotNull
     @JsonProperty("last_updated")
     @JsonDeserialize(using = OCPILocalDateTimeDeserializer.class)

--- a/src/main/java/com/banula/openlib/ocpi/model/dto/ChargingSessionDTO.java
+++ b/src/main/java/com/banula/openlib/ocpi/model/dto/ChargingSessionDTO.java
@@ -24,7 +24,7 @@ import java.util.List;
 @AllArgsConstructor
 @NoArgsConstructor
 @Builder
-public class SessionDTO {
+public class ChargingSessionDTO {
     @NotEmpty
     @Size(min = 1, max = 2)
     @JsonProperty("country_code")


### PR DESCRIPTION
- [x] Tariff Manager: Update imports to use the new Open Library 0.1.4
- [x] Navigation Service: Update imports to use the new Open Library 0.1.4
- [x] OpenLib: Create ChargingSessionMapper and rename SessionDTO to ChargingSessionDTO 
- [x] Platform: improve error handling on outflow requests | propagate ocn node status errors. Today if a non existent url is requested by cpo for example ocn provide 404 to platform but platform is providing 500 to cpo. 
- [x] Platform BUGFIX:  Writing [{status=500, error=Internal Server Error, message=Unrecognized field "status" (class snc.openchargingnetwork.node.models.ocpi.OcpiResponse), not marked as ignorable (5 known properties: "status_code", "ocn_signature", "timestamp", "status_message", "data"]). Today we see this strange error in the Ocn Node that does not say any thing, update errors sent to Ocn Node to be Ocpi compliant and meaningful