### PR TITLE
OLISYS-4724: hub party role

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ Add the following dependency to your project's `pom.xml`:
 <dependency>
     <groupId>energy.oli</groupId>
     <artifactId>banula-open-library</artifactId>
-    <version>1.1.7</version>
+    <version>1.2.2</version>
 </dependency>
 ```
 
 For Gradle users, add to your `build.gradle`:
 
 ```groovy
-implementation 'energy.oli:banula-open-library:1.1.7'
+implementation 'energy.oli:banula-open-library:1.2.2'
 ```
 
 ## Quick Start

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>energy.oli</groupId>
     <artifactId>banula-open-library</artifactId>
-    <version>1.2.1</version>
+    <version>1.2.2</version>
     <packaging>jar</packaging>
 
     <name>banula-open-library</name>

--- a/src/main/java/com/banula/openlib/ocn/client/OcnClient.java
+++ b/src/main/java/com/banula/openlib/ocn/client/OcnClient.java
@@ -142,7 +142,7 @@ public class OcnClient {
         CreatePlatformResponse platformResponse = this.createPlatform();
 
         // Get token A from platform response or use configured TokenA as fallback
-        String tokenA = platformResponse.getToken();
+        String tokenA = platformResponse.getTokenA();
         if (tokenA == null || tokenA.isBlank()) {
             log.warn("OCN Node returned null/empty TokenA, using configured TokenA");
             tokenA = configuration.getTokenA();
@@ -157,7 +157,7 @@ public class OcnClient {
         configuration.setTokenA(tokenA);
 
         // Get versions URL from response or construct default
-        String versionsUrl = platformResponse.getVersions();
+        String versionsUrl = platformResponse.getVersionsUrl();
         if (versionsUrl == null || versionsUrl.isBlank()) {
             versionsUrl = configuration.getNodeUrl() + "/ocpi/versions";
             log.warn("OCN Node returned null/empty versions URL, using default: {}", versionsUrl);

--- a/src/main/java/com/banula/openlib/ocn/client/OcnEndpoints.java
+++ b/src/main/java/com/banula/openlib/ocn/client/OcnEndpoints.java
@@ -3,7 +3,7 @@ package com.banula.openlib.ocn.client;
 public enum OcnEndpoints {
     // Admin endpoints
     CREATE_PLATFORM("/admin/platform"),
-    DELETE_PARTY_CREDENTIALS("/admin/party"),
+    DELETE_PARTY_CREDENTIALS("/admin/platform-by-party"),
 
     // OCPI MAIN ENDPOINTS
     VERSIONS("/ocpi/versions"),

--- a/src/main/java/com/banula/openlib/ocn/model/CreatePlatformResponse.java
+++ b/src/main/java/com/banula/openlib/ocn/model/CreatePlatformResponse.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import lombok.ToString;
 
 @Data
 @AllArgsConstructor
@@ -12,13 +13,21 @@ import lombok.NoArgsConstructor;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CreatePlatformResponse {
     /** Legacy flat token field (older node responses). */
+    @ToString.Exclude
     private String token;
     /** Legacy flat versions URL field (older node responses). */
     private String versions;
     /** Nested auth from ocn-node-v2 PlatformEntity responses. */
+    @ToString.Exclude
     private Auth auth;
     /** versionsUrl from ocn-node-v2 PlatformEntity responses. */
     private String versionsUrl;
+
+    /** Compatibility constructor for legacy flat response fields. */
+    public CreatePlatformResponse(String token, String versions) {
+        this.token = token;
+        this.versions = versions;
+    }
 
     public String getToken() {
         if (token != null && !token.isBlank()) {
@@ -39,9 +48,13 @@ public class CreatePlatformResponse {
     @NoArgsConstructor
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class Auth {
+        @ToString.Exclude
         private String tokenA;
+        @ToString.Exclude
         private String tokenB;
+        @ToString.Exclude
         private String tokenC;
+        @ToString.Exclude
         private String selfCredentialsToken;
         private Boolean handshakeSelfInitiated;
     }

--- a/src/main/java/com/banula/openlib/ocn/model/CreatePlatformResponse.java
+++ b/src/main/java/com/banula/openlib/ocn/model/CreatePlatformResponse.java
@@ -8,16 +8,49 @@ import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 @Data
-@AllArgsConstructor
 @NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CreatePlatformResponse {
+    /** Legacy flat token field (older node responses). */
+    @ToString.Exclude
+    private String token;
+    /** Legacy flat versions URL field (older node responses). */
+    private String versions;
+    /** Nested auth from ocn-node-v2 PlatformEntity responses. */
     @ToString.Exclude
     private Auth auth;
+    /** versionsUrl from ocn-node-v2 PlatformEntity responses. */
     private String versionsUrl;
 
+    /** Compatibility constructor matching the published (token, versions) API. */
+    public CreatePlatformResponse(String token, String versions) {
+        this.token = token;
+        this.versions = versions;
+    }
+
+    /**
+     * Token A from nested {@code auth.tokenA}, falling back to the legacy flat
+     * {@code token} when auth is absent or its tokenA is blank.
+     */
     public String getTokenA() {
-        return auth != null ? auth.getTokenA() : null;
+        if (auth != null) {
+            String nested = auth.getTokenA();
+            if (nested != null && !nested.isBlank()) {
+                return nested;
+            }
+        }
+        return token;
+    }
+
+    /**
+     * Versions URL from nested {@code versionsUrl}, falling back to the legacy
+     * flat {@code versions} field when the nested value is absent or blank.
+     */
+    public String getVersionsUrl() {
+        if (versionsUrl != null && !versionsUrl.isBlank()) {
+            return versionsUrl;
+        }
+        return versions;
     }
 
     @Data

--- a/src/main/java/com/banula/openlib/ocn/model/CreatePlatformResponse.java
+++ b/src/main/java/com/banula/openlib/ocn/model/CreatePlatformResponse.java
@@ -1,5 +1,7 @@
 package com.banula.openlib.ocn.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -7,7 +9,40 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class CreatePlatformResponse {
+    /** Legacy flat token field (older node responses). */
     private String token;
+    /** Legacy flat versions URL field (older node responses). */
     private String versions;
+    /** Nested auth from ocn-node-v2 PlatformEntity responses. */
+    private Auth auth;
+    /** versionsUrl from ocn-node-v2 PlatformEntity responses. */
+    private String versionsUrl;
+
+    public String getToken() {
+        if (token != null && !token.isBlank()) {
+            return token;
+        }
+        return auth != null ? auth.getTokenA() : null;
+    }
+
+    public String getVersions() {
+        if (versions != null && !versions.isBlank()) {
+            return versions;
+        }
+        return versionsUrl;
+    }
+
+    @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    public static class Auth {
+        private String tokenA;
+        private String tokenB;
+        private String tokenC;
+        private String selfCredentialsToken;
+        private Boolean handshakeSelfInitiated;
+    }
 }

--- a/src/main/java/com/banula/openlib/ocn/model/CreatePlatformResponse.java
+++ b/src/main/java/com/banula/openlib/ocn/model/CreatePlatformResponse.java
@@ -12,35 +12,12 @@ import lombok.ToString;
 @NoArgsConstructor
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CreatePlatformResponse {
-    /** Legacy flat token field (older node responses). */
-    @ToString.Exclude
-    private String token;
-    /** Legacy flat versions URL field (older node responses). */
-    private String versions;
-    /** Nested auth from ocn-node-v2 PlatformEntity responses. */
     @ToString.Exclude
     private Auth auth;
-    /** versionsUrl from ocn-node-v2 PlatformEntity responses. */
     private String versionsUrl;
 
-    /** Compatibility constructor for legacy flat response fields. */
-    public CreatePlatformResponse(String token, String versions) {
-        this.token = token;
-        this.versions = versions;
-    }
-
-    public String getToken() {
-        if (token != null && !token.isBlank()) {
-            return token;
-        }
+    public String getTokenA() {
         return auth != null ? auth.getTokenA() : null;
-    }
-
-    public String getVersions() {
-        if (versions != null && !versions.isBlank()) {
-            return versions;
-        }
-        return versionsUrl;
     }
 
     @Data

--- a/src/test/java/com/banula/openlib/ocn/model/CreatePlatformResponseTest.java
+++ b/src/test/java/com/banula/openlib/ocn/model/CreatePlatformResponseTest.java
@@ -13,8 +13,26 @@ class CreatePlatformResponseTest {
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
-    @DisplayName("Deserializes auth.tokenA and versionsUrl")
-    void deserializesPlatformEntityShape() throws Exception {
+    @DisplayName("Deserializes legacy flat token and versions fields")
+    void legacyFlatFields() throws Exception {
+        String json = """
+                {
+                  "token": "legacy-token",
+                  "versions": "https://example.com/ocpi/versions"
+                }
+                """;
+
+        CreatePlatformResponse response = objectMapper.readValue(json, CreatePlatformResponse.class);
+
+        assertEquals("legacy-token", response.getToken());
+        assertEquals("https://example.com/ocpi/versions", response.getVersions());
+        assertEquals("legacy-token", response.getTokenA());
+        assertEquals("https://example.com/ocpi/versions", response.getVersionsUrl());
+    }
+
+    @Test
+    @DisplayName("Deserializes nested auth.tokenA and versionsUrl")
+    void nestedAuthAndVersionsUrl() throws Exception {
         String json = """
                 {
                   "auth": {
@@ -24,15 +42,74 @@ class CreatePlatformResponseTest {
                     "selfCredentialsToken": "self-token",
                     "handshakeSelfInitiated": true
                   },
-                  "versionsUrl": "https://example.com/ocpi/versions"
+                  "versionsUrl": "https://example.com/ocpi/versions-v2"
                 }
                 """;
 
         CreatePlatformResponse response = objectMapper.readValue(json, CreatePlatformResponse.class);
 
         assertEquals("nested-token-a", response.getTokenA());
-        assertEquals("https://example.com/ocpi/versions", response.getVersionsUrl());
+        assertEquals("https://example.com/ocpi/versions-v2", response.getVersionsUrl());
         assertEquals(true, response.getAuth().getHandshakeSelfInitiated());
+    }
+
+    @Test
+    @DisplayName("Falls back to nested values when legacy fields are blank")
+    void blankLegacyFallsBackToNested() throws Exception {
+        String json = """
+                {
+                  "token": "   ",
+                  "versions": "",
+                  "auth": {
+                    "tokenA": "fallback-token-a"
+                  },
+                  "versionsUrl": "https://example.com/ocpi/versions-fallback"
+                }
+                """;
+
+        CreatePlatformResponse response = objectMapper.readValue(json, CreatePlatformResponse.class);
+
+        assertEquals("fallback-token-a", response.getTokenA());
+        assertEquals("https://example.com/ocpi/versions-fallback", response.getVersionsUrl());
+    }
+
+    @Test
+    @DisplayName("Falls back to legacy token when auth is absent")
+    void tokenAFallsBackToLegacyWhenAuthAbsent() throws Exception {
+        String json = """
+                {
+                  "token": "legacy-token",
+                  "versions": "https://example.com/ocpi/versions"
+                }
+                """;
+
+        CreatePlatformResponse response = objectMapper.readValue(json, CreatePlatformResponse.class);
+
+        assertNull(response.getAuth());
+        assertEquals("legacy-token", response.getTokenA());
+        assertEquals("https://example.com/ocpi/versions", response.getVersionsUrl());
+    }
+
+    @Test
+    @DisplayName("Prefers nested auth.tokenA over legacy token when both are present")
+    void prefersNestedTokenAWhenPresent() throws Exception {
+        String json = """
+                {
+                  "token": "legacy-token",
+                  "versions": "https://example.com/ocpi/versions-legacy",
+                  "auth": {
+                    "tokenA": "nested-token-a"
+                  },
+                  "versionsUrl": "https://example.com/ocpi/versions-v2"
+                }
+                """;
+
+        CreatePlatformResponse response = objectMapper.readValue(json, CreatePlatformResponse.class);
+
+        assertEquals("nested-token-a", response.getTokenA());
+        assertEquals("https://example.com/ocpi/versions-v2", response.getVersionsUrl());
+        assertEquals("legacy-token", response.getToken());
+        assertEquals("https://example.com/ocpi/versions-legacy", response.getVersions());
     }
 
     @Test
@@ -40,28 +117,47 @@ class CreatePlatformResponseTest {
     void ignoresUnknownProperties() throws Exception {
         String json = """
                 {
+                  "token": "legacy-token",
+                  "versions": "https://example.com/ocpi/versions",
                   "unknownField": "should-be-ignored",
                   "auth": {
                     "tokenA": "nested-token-a",
                     "extraAuthField": 123
-                  },
-                  "versionsUrl": "https://example.com/ocpi/versions"
+                  }
                 }
                 """;
 
         CreatePlatformResponse response = objectMapper.readValue(json, CreatePlatformResponse.class);
 
+        assertEquals("legacy-token", response.getToken());
+        assertEquals("https://example.com/ocpi/versions", response.getVersions());
+        assertEquals("nested-token-a", response.getAuth().getTokenA());
         assertEquals("nested-token-a", response.getTokenA());
-        assertEquals("https://example.com/ocpi/versions", response.getVersionsUrl());
     }
 
     @Test
-    @DisplayName("Returns null when auth or versionsUrl are missing")
+    @DisplayName("Two-arg constructor sets legacy token and versions")
+    void twoArgConstructorSetsLegacyFields() {
+        CreatePlatformResponse response = new CreatePlatformResponse(
+                "ctor-token",
+                "https://example.com/ocpi/versions");
+
+        assertEquals("ctor-token", response.getToken());
+        assertEquals("https://example.com/ocpi/versions", response.getVersions());
+        assertEquals("ctor-token", response.getTokenA());
+        assertEquals("https://example.com/ocpi/versions", response.getVersionsUrl());
+        assertNull(response.getAuth());
+    }
+
+    @Test
+    @DisplayName("Returns null when no token or versions are available")
     void returnsNullWhenMissing() throws Exception {
         CreatePlatformResponse response = objectMapper.readValue("{}", CreatePlatformResponse.class);
 
         assertNull(response.getTokenA());
         assertNull(response.getVersionsUrl());
+        assertNull(response.getToken());
+        assertNull(response.getVersions());
     }
 
     @Test
@@ -74,12 +170,15 @@ class CreatePlatformResponseTest {
                 "secret-self-token",
                 true);
         CreatePlatformResponse response = new CreatePlatformResponse(
-                auth,
+                "secret-token",
                 "https://example.com/ocpi/versions");
+        response.setAuth(auth);
+        response.setVersionsUrl("https://example.com/ocpi/versions-v2");
 
         String responseString = response.toString();
         String authString = auth.toString();
 
+        assertFalse(responseString.contains("secret-token"));
         assertFalse(responseString.contains("secret-token-a"));
         assertFalse(responseString.contains("secret-self-token"));
         assertFalse(authString.contains("secret-token-a"));

--- a/src/test/java/com/banula/openlib/ocn/model/CreatePlatformResponseTest.java
+++ b/src/test/java/com/banula/openlib/ocn/model/CreatePlatformResponseTest.java
@@ -1,0 +1,150 @@
+package com.banula.openlib.ocn.model;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class CreatePlatformResponseTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Test
+    @DisplayName("Deserializes legacy flat token and versions fields")
+    void legacyFlatFields() throws Exception {
+        String json = """
+                {
+                  "token": "legacy-token",
+                  "versions": "https://example.com/ocpi/versions"
+                }
+                """;
+
+        CreatePlatformResponse response = objectMapper.readValue(json, CreatePlatformResponse.class);
+
+        assertEquals("legacy-token", response.getToken());
+        assertEquals("https://example.com/ocpi/versions", response.getVersions());
+    }
+
+    @Test
+    @DisplayName("Deserializes nested auth.tokenA and versionsUrl")
+    void nestedAuthAndVersionsUrl() throws Exception {
+        String json = """
+                {
+                  "auth": {
+                    "tokenA": "nested-token-a",
+                    "tokenB": "nested-token-b",
+                    "tokenC": "nested-token-c",
+                    "selfCredentialsToken": "self-token",
+                    "handshakeSelfInitiated": true
+                  },
+                  "versionsUrl": "https://example.com/ocpi/versions-v2"
+                }
+                """;
+
+        CreatePlatformResponse response = objectMapper.readValue(json, CreatePlatformResponse.class);
+
+        assertEquals("nested-token-a", response.getToken());
+        assertEquals("https://example.com/ocpi/versions-v2", response.getVersions());
+    }
+
+    @Test
+    @DisplayName("Falls back to nested values when legacy fields are blank")
+    void blankLegacyFallsBackToNested() throws Exception {
+        String json = """
+                {
+                  "token": "   ",
+                  "versions": "",
+                  "auth": {
+                    "tokenA": "fallback-token-a"
+                  },
+                  "versionsUrl": "https://example.com/ocpi/versions-fallback"
+                }
+                """;
+
+        CreatePlatformResponse response = objectMapper.readValue(json, CreatePlatformResponse.class);
+
+        assertEquals("fallback-token-a", response.getToken());
+        assertEquals("https://example.com/ocpi/versions-fallback", response.getVersions());
+    }
+
+    @Test
+    @DisplayName("Ignores unknown JSON properties")
+    void ignoresUnknownProperties() throws Exception {
+        String json = """
+                {
+                  "token": "legacy-token",
+                  "versions": "https://example.com/ocpi/versions",
+                  "unknownField": "should-be-ignored",
+                  "auth": {
+                    "tokenA": "nested-token-a",
+                    "extraAuthField": 123
+                  }
+                }
+                """;
+
+        CreatePlatformResponse response = objectMapper.readValue(json, CreatePlatformResponse.class);
+
+        assertEquals("legacy-token", response.getToken());
+        assertEquals("https://example.com/ocpi/versions", response.getVersions());
+        assertEquals("nested-token-a", response.getAuth().getTokenA());
+    }
+
+    @Test
+    @DisplayName("Prefers non-blank legacy fields over nested values")
+    void prefersLegacyWhenPresent() throws Exception {
+        String json = """
+                {
+                  "token": "legacy-token",
+                  "versions": "https://example.com/ocpi/versions-legacy",
+                  "auth": {
+                    "tokenA": "nested-token-a"
+                  },
+                  "versionsUrl": "https://example.com/ocpi/versions-v2"
+                }
+                """;
+
+        CreatePlatformResponse response = objectMapper.readValue(json, CreatePlatformResponse.class);
+
+        assertEquals("legacy-token", response.getToken());
+        assertEquals("https://example.com/ocpi/versions-legacy", response.getVersions());
+    }
+
+    @Test
+    @DisplayName("Returns null when no token or versions are available")
+    void returnsNullWhenMissing() throws Exception {
+        CreatePlatformResponse response = objectMapper.readValue("{}", CreatePlatformResponse.class);
+
+        assertNull(response.getToken());
+        assertNull(response.getVersions());
+    }
+
+    @Test
+    @DisplayName("toString excludes credential fields")
+    void toStringExcludesCredentials() {
+        CreatePlatformResponse.Auth auth = new CreatePlatformResponse.Auth(
+                "secret-token-a",
+                "secret-token-b",
+                "secret-token-c",
+                "secret-self-token",
+                true);
+        CreatePlatformResponse response = new CreatePlatformResponse(
+                "secret-token",
+                "https://example.com/ocpi/versions",
+                auth,
+                "https://example.com/ocpi/versions-v2");
+
+        String responseString = response.toString();
+        String authString = auth.toString();
+
+        assertFalse(responseString.contains("secret-token"));
+        assertFalse(responseString.contains("secret-token-a"));
+        assertFalse(responseString.contains("secret-self-token"));
+        assertFalse(authString.contains("secret-token-a"));
+        assertFalse(authString.contains("secret-token-b"));
+        assertFalse(authString.contains("secret-token-c"));
+        assertFalse(authString.contains("secret-self-token"));
+    }
+}

--- a/src/test/java/com/banula/openlib/ocn/model/CreatePlatformResponseTest.java
+++ b/src/test/java/com/banula/openlib/ocn/model/CreatePlatformResponseTest.java
@@ -13,24 +13,8 @@ class CreatePlatformResponseTest {
     private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Test
-    @DisplayName("Deserializes legacy flat token and versions fields")
-    void legacyFlatFields() throws Exception {
-        String json = """
-                {
-                  "token": "legacy-token",
-                  "versions": "https://example.com/ocpi/versions"
-                }
-                """;
-
-        CreatePlatformResponse response = objectMapper.readValue(json, CreatePlatformResponse.class);
-
-        assertEquals("legacy-token", response.getToken());
-        assertEquals("https://example.com/ocpi/versions", response.getVersions());
-    }
-
-    @Test
-    @DisplayName("Deserializes nested auth.tokenA and versionsUrl")
-    void nestedAuthAndVersionsUrl() throws Exception {
+    @DisplayName("Deserializes auth.tokenA and versionsUrl")
+    void deserializesPlatformEntityShape() throws Exception {
         String json = """
                 {
                   "auth": {
@@ -40,34 +24,15 @@ class CreatePlatformResponseTest {
                     "selfCredentialsToken": "self-token",
                     "handshakeSelfInitiated": true
                   },
-                  "versionsUrl": "https://example.com/ocpi/versions-v2"
+                  "versionsUrl": "https://example.com/ocpi/versions"
                 }
                 """;
 
         CreatePlatformResponse response = objectMapper.readValue(json, CreatePlatformResponse.class);
 
-        assertEquals("nested-token-a", response.getToken());
-        assertEquals("https://example.com/ocpi/versions-v2", response.getVersions());
-    }
-
-    @Test
-    @DisplayName("Falls back to nested values when legacy fields are blank")
-    void blankLegacyFallsBackToNested() throws Exception {
-        String json = """
-                {
-                  "token": "   ",
-                  "versions": "",
-                  "auth": {
-                    "tokenA": "fallback-token-a"
-                  },
-                  "versionsUrl": "https://example.com/ocpi/versions-fallback"
-                }
-                """;
-
-        CreatePlatformResponse response = objectMapper.readValue(json, CreatePlatformResponse.class);
-
-        assertEquals("fallback-token-a", response.getToken());
-        assertEquals("https://example.com/ocpi/versions-fallback", response.getVersions());
+        assertEquals("nested-token-a", response.getTokenA());
+        assertEquals("https://example.com/ocpi/versions", response.getVersionsUrl());
+        assertEquals(true, response.getAuth().getHandshakeSelfInitiated());
     }
 
     @Test
@@ -75,50 +40,28 @@ class CreatePlatformResponseTest {
     void ignoresUnknownProperties() throws Exception {
         String json = """
                 {
-                  "token": "legacy-token",
-                  "versions": "https://example.com/ocpi/versions",
                   "unknownField": "should-be-ignored",
                   "auth": {
                     "tokenA": "nested-token-a",
                     "extraAuthField": 123
-                  }
-                }
-                """;
-
-        CreatePlatformResponse response = objectMapper.readValue(json, CreatePlatformResponse.class);
-
-        assertEquals("legacy-token", response.getToken());
-        assertEquals("https://example.com/ocpi/versions", response.getVersions());
-        assertEquals("nested-token-a", response.getAuth().getTokenA());
-    }
-
-    @Test
-    @DisplayName("Prefers non-blank legacy fields over nested values")
-    void prefersLegacyWhenPresent() throws Exception {
-        String json = """
-                {
-                  "token": "legacy-token",
-                  "versions": "https://example.com/ocpi/versions-legacy",
-                  "auth": {
-                    "tokenA": "nested-token-a"
                   },
-                  "versionsUrl": "https://example.com/ocpi/versions-v2"
+                  "versionsUrl": "https://example.com/ocpi/versions"
                 }
                 """;
 
         CreatePlatformResponse response = objectMapper.readValue(json, CreatePlatformResponse.class);
 
-        assertEquals("legacy-token", response.getToken());
-        assertEquals("https://example.com/ocpi/versions-legacy", response.getVersions());
+        assertEquals("nested-token-a", response.getTokenA());
+        assertEquals("https://example.com/ocpi/versions", response.getVersionsUrl());
     }
 
     @Test
-    @DisplayName("Returns null when no token or versions are available")
+    @DisplayName("Returns null when auth or versionsUrl are missing")
     void returnsNullWhenMissing() throws Exception {
         CreatePlatformResponse response = objectMapper.readValue("{}", CreatePlatformResponse.class);
 
-        assertNull(response.getToken());
-        assertNull(response.getVersions());
+        assertNull(response.getTokenA());
+        assertNull(response.getVersionsUrl());
     }
 
     @Test
@@ -131,15 +74,12 @@ class CreatePlatformResponseTest {
                 "secret-self-token",
                 true);
         CreatePlatformResponse response = new CreatePlatformResponse(
-                "secret-token",
-                "https://example.com/ocpi/versions",
                 auth,
-                "https://example.com/ocpi/versions-v2");
+                "https://example.com/ocpi/versions");
 
         String responseString = response.toString();
         String authString = auth.toString();
 
-        assertFalse(responseString.contains("secret-token"));
         assertFalse(responseString.contains("secret-token-a"));
         assertFalse(responseString.contains("secret-self-token"));
         assertFalse(authString.contains("secret-token-a"));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary
- Updated `OcnEndpoints.DELETE_PARTY_CREDENTIALS` to use `/admin/platform-by-party`.
- Enhanced `CreatePlatformResponse` to support legacy flat fields and nested authentication data.
- Preserved the two-argument constructor for API compatibility.
- Updated `OcnClient.registerParty` to use `tokenA` and `versionsUrl`.
- Excluded credential fields from `toString`.
- Added tests for parsing, fallback behavior, unknown properties, empty JSON, constructor behavior, and credential exclusion.
- Updated the project version and dependency examples to `1.2.2`.

## Aditional info from review-info MCP
| Field | Value |
|-------|-------|
| **Found** | ✅ `true` |
| **Repository** | `banula-open-library` |
| **Project** | **Transit** (`transit`) |

### Repository Description
Shared Java library used across Banula services. Contains common utilities, models, and helpers. Dependency for private-lib and multiple backend services. Published to local Maven repository.

## Project Description
The **Transit** project is an EV charging and roaming platform implementing **OCPI 2.2.1** and **OCPP 1.6** protocols.
It consists of a distributed microservices architecture supporting:
- CPO/eMSP operations
- Billing
- Tariff management
- Roaming (OCN node)
- Admin dashboards
<!-- end of auto-generated comment: release notes by coderabbit.ai -->