### PR TITLE
Feature/olisys 4249/change namespace

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Banula Open Library
 
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.my-oli/banula-open-library/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.my-oli/banula-open-library)
+[![Maven Central](https://maven-badges.herokuapp.com/maven-central/energy.oli/banula-open-library/badge.svg)](https://maven-badges.herokuapp.com/maven-central/energy.oli/banula-open-library)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 ## Introduction
@@ -44,7 +44,7 @@ Add the following dependency to your project's `pom.xml`:
 
 ```xml
 <dependency>
-    <groupId>com.my-oli</groupId>
+    <groupId>energy.oli</groupId>
     <artifactId>banula-open-library</artifactId>
     <version>1.0.3</version>
 </dependency>
@@ -53,7 +53,7 @@ Add the following dependency to your project's `pom.xml`:
 For Gradle users, add to your `build.gradle`:
 
 ```groovy
-implementation 'com.my-oli:banula-open-library:1.0.3'
+implementation 'energy.oli:banula-open-library:1.0.3'
 ```
 
 ## Quick Start

--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ Add the following dependency to your project's `pom.xml`:
 <dependency>
     <groupId>energy.oli</groupId>
     <artifactId>banula-open-library</artifactId>
-    <version>1.0.3</version>
+    <version>1.1.7</version>
 </dependency>
 ```
 
 For Gradle users, add to your `build.gradle`:
 
 ```groovy
-implementation 'energy.oli:banula-open-library:1.0.3'
+implementation 'energy.oli:banula-open-library:1.1.7'
 ```
 
 ## Quick Start

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.my-oli</groupId>
     <artifactId>banula-open-library</artifactId>
-    <version>1.1.6</version>
+    <version>1.1.7</version>
     <packaging>jar</packaging>
 
     <name>banula-open-library</name>

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project>
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.my-oli</groupId>
+    <groupId>energy.oli</groupId>
     <artifactId>banula-open-library</artifactId>
     <version>1.1.7</version>
     <packaging>jar</packaging>
@@ -259,7 +259,7 @@
             <plugin>
                 <groupId>org.sonatype.central</groupId>
                 <artifactId>central-publishing-maven-plugin</artifactId>
-                <version>0.7.0</version>
+                <version>0.11.0</version>
                 <extensions>true</extensions>
                 <configuration>
                     <publishingServerId>central</publishingServerId>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>energy.oli</groupId>
     <artifactId>banula-open-library</artifactId>
-    <version>1.1.7</version>
+    <version>1.1.8</version>
     <packaging>jar</packaging>
 
     <name>banula-open-library</name>

--- a/src/main/java/com/banula/openlib/ocpi/custom/smartlocations/SmartLocationState.java
+++ b/src/main/java/com/banula/openlib/ocpi/custom/smartlocations/SmartLocationState.java
@@ -6,5 +6,6 @@ public enum SmartLocationState {
     ENRICHED,
     VERIFIED,
     INVALID,
-    ARCHIVED
+    ARCHIVED,
+    ACTIVE
 }

--- a/src/main/java/com/banula/openlib/ocpi/model/CDR.java
+++ b/src/main/java/com/banula/openlib/ocpi/model/CDR.java
@@ -1,5 +1,6 @@
 package com.banula.openlib.ocpi.model;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -198,7 +199,7 @@ public class CDR {
      */
     @JsonProperty("total_energy")
     @NotNull(message = "Total energy cannot be null")
-    private Float totalEnergy;
+    private BigDecimal totalEnergy;
 
     /**
      * Total sum of all the cost of all the energy used, in the specified currency.

--- a/src/main/java/com/banula/openlib/ocpi/model/ChargingSession.java
+++ b/src/main/java/com/banula/openlib/ocpi/model/ChargingSession.java
@@ -1,5 +1,6 @@
 package com.banula.openlib.ocpi.model;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -39,7 +40,7 @@ public class ChargingSession {
     @JsonDeserialize(using = OCPILocalDateTimeDeserializer.class)
     @JsonSerialize(using = OCPILocalDateTimeSerializer.class)
     private LocalDateTime endDateTime;
-    private Float kwh;
+    private BigDecimal kwh;
     private CdrToken cdrToken;
     private AuthMethod authMethod;
     private String authorizationReference;

--- a/src/main/java/com/banula/openlib/ocpi/model/dto/CdrDTO.java
+++ b/src/main/java/com/banula/openlib/ocpi/model/dto/CdrDTO.java
@@ -1,5 +1,6 @@
 package com.banula.openlib.ocpi.model.dto;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -106,7 +107,7 @@ public class CdrDTO {
 
     @NotNull(message = "Total energy must not be blank")
     @JsonProperty("total_energy")
-    private Float totalEnergy;
+    private BigDecimal totalEnergy;
 
     @JsonProperty("total_energy_cost")
     @Valid

--- a/src/main/java/com/banula/openlib/ocpi/model/dto/ChargingSessionDTO.java
+++ b/src/main/java/com/banula/openlib/ocpi/model/dto/ChargingSessionDTO.java
@@ -1,5 +1,6 @@
 package com.banula.openlib.ocpi.model.dto;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -56,7 +57,7 @@ public class ChargingSessionDTO {
     @NotNull
     @Digits(integer = Integer.MAX_VALUE, fraction = 4)
     @JsonProperty("kwh")
-    private Float kwh;
+    private BigDecimal kwh;
     @NotNull
     @JsonProperty("cdr_token")
     @Valid

--- a/src/main/java/com/banula/openlib/ocpi/model/vo/CdrDimension.java
+++ b/src/main/java/com/banula/openlib/ocpi/model/vo/CdrDimension.java
@@ -1,5 +1,7 @@
 package com.banula.openlib.ocpi.model.vo;
 
+import java.math.BigDecimal;
+
 import com.banula.openlib.ocpi.model.enums.CdrDimensionType;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -32,13 +34,13 @@ public class CdrDimension {
      */
     @JsonProperty("volume")
     @Digits(integer = Integer.MAX_VALUE, fraction = 4)
-    private Float volume;
+    private BigDecimal volume;
 
     public void setType(CdrDimensionType type) {
         this.type = type;
     }
 
-    public void setVolume(Float volume) {
+    public void setVolume(BigDecimal volume) {
         this.volume = volume;
     }
 

--- a/src/main/java/com/banula/openlib/ocpi/util/Constants.java
+++ b/src/main/java/com/banula/openlib/ocpi/util/Constants.java
@@ -3,6 +3,7 @@ package com.banula.openlib.ocpi.util;
 public final class Constants {
 
     public static final String ASCII_REGEXP = "^[\\p{ASCII}]*$";
+    public static final int STATUS_CODE_GENERIC_CLIENT_ERROR = 2000;
     public static final int STATUS_CODE_INVALID_OR_MISSING_PARAMETERS = 2001;
     public static final int STATUS_CODE_AUTHORIZATION_EXCEPTION_CODE = 2002;
     public static final int STATUS_CODE_NOT_ENOUGH_INFORMATION = 2002;

--- a/src/test/java/com/banula/openlib/ocpi/platform/PlatformClientOcpiComplianceTest.java
+++ b/src/test/java/com/banula/openlib/ocpi/platform/PlatformClientOcpiComplianceTest.java
@@ -12,6 +12,7 @@ import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
@@ -205,7 +206,7 @@ public class PlatformClientOcpiComplianceTest {
                 .build());
         dto.setChargingPeriods(List.of());
         dto.setTotalCost(new Price(0.0f));
-        dto.setTotalEnergy(1.0f);
+        dto.setTotalEnergy(BigDecimal.valueOf(1.0));
         dto.setTotalTime(0.5f);
         dto.setLastUpdated(LocalDateTime.now(ZoneOffset.UTC));
         try {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Changed Maven coordinates from `com.my-oli` to `energy.oli`.
- Updated the Maven version to `1.1.8`.
- Updated README dependency examples to version `1.1.7`.
- Upgraded the Sonatype Central publishing plugin to `0.11.0`.
- Added the `ACTIVE` state to `SmartLocationState`.
- Changed CDR energy, charging-session energy, and CDR dimension volume fields from `Float` to `BigDecimal`.
- Added `STATUS_CODE_GENERIC_CLIENT_ERROR` with value `2000`.
- Updated the related compliance test.

## Aditional info from review-info MCP

| Field | Value |
|-------|-------|
| **Found** | ✅ `true` |
| **Repository** | `banula-open-library` |
| **Project** | **Transit** (`transit`) |

### Repository Description

Shared Java library used across Banula services. It contains common utilities, models, and helpers. The library is published to a local Maven repository.

### Project Description

The **Transit** project is an EV charging and roaming platform implementing **OCPI 2.2.1** and **OCPP 1.6** protocols. It supports CPO/eMSP operations, billing, tariff management, roaming through the OCN node, and admin dashboards.

### Review Instructions

- Verify OCPI/OCPP implementations against OCPI 2.2.1-d2 and OCPP 1.6.
- Verify BFF frontends use Go BFF endpoints for backend requests.
- Verify MongoDB service-prefixed collection names and database usage.
- Check dependency compatibility because `private-lib` depends on `banula-open-library`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->