### PR TITLE
OLISYS-4249 -> develop | release 1.1.7 and BigDecimal OCPI values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.my-oli</groupId>
     <artifactId>banula-open-library</artifactId>
-    <version>1.1.6</version>
+    <version>1.1.7</version>
     <packaging>jar</packaging>
 
     <name>banula-open-library</name>

--- a/src/main/java/com/banula/openlib/ocpi/custom/smartlocations/SmartLocationState.java
+++ b/src/main/java/com/banula/openlib/ocpi/custom/smartlocations/SmartLocationState.java
@@ -6,5 +6,6 @@ public enum SmartLocationState {
     ENRICHED,
     VERIFIED,
     INVALID,
-    ARCHIVED
+    ARCHIVED,
+    ACTIVE
 }

--- a/src/main/java/com/banula/openlib/ocpi/model/CDR.java
+++ b/src/main/java/com/banula/openlib/ocpi/model/CDR.java
@@ -1,5 +1,6 @@
 package com.banula.openlib.ocpi.model;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -198,7 +199,7 @@ public class CDR {
      */
     @JsonProperty("total_energy")
     @NotNull(message = "Total energy cannot be null")
-    private Float totalEnergy;
+    private BigDecimal totalEnergy;
 
     /**
      * Total sum of all the cost of all the energy used, in the specified currency.

--- a/src/main/java/com/banula/openlib/ocpi/model/dto/CdrDTO.java
+++ b/src/main/java/com/banula/openlib/ocpi/model/dto/CdrDTO.java
@@ -1,5 +1,6 @@
 package com.banula.openlib.ocpi.model.dto;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -106,7 +107,7 @@ public class CdrDTO {
 
     @NotNull(message = "Total energy must not be blank")
     @JsonProperty("total_energy")
-    private Float totalEnergy;
+    private BigDecimal totalEnergy;
 
     @JsonProperty("total_energy_cost")
     @Valid

--- a/src/main/java/com/banula/openlib/ocpi/model/vo/CdrDimension.java
+++ b/src/main/java/com/banula/openlib/ocpi/model/vo/CdrDimension.java
@@ -1,5 +1,7 @@
 package com.banula.openlib.ocpi.model.vo;
 
+import java.math.BigDecimal;
+
 import com.banula.openlib.ocpi.model.enums.CdrDimensionType;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -32,13 +34,13 @@ public class CdrDimension {
      */
     @JsonProperty("volume")
     @Digits(integer = Integer.MAX_VALUE, fraction = 4)
-    private Float volume;
+    private BigDecimal volume;
 
     public void setType(CdrDimensionType type) {
         this.type = type;
     }
 
-    public void setVolume(Float volume) {
+    public void setVolume(BigDecimal volume) {
         this.volume = volume;
     }
 

--- a/src/main/java/com/banula/openlib/ocpi/util/Constants.java
+++ b/src/main/java/com/banula/openlib/ocpi/util/Constants.java
@@ -3,6 +3,7 @@ package com.banula.openlib.ocpi.util;
 public final class Constants {
 
     public static final String ASCII_REGEXP = "^[\\p{ASCII}]*$";
+    public static final int STATUS_CODE_GENERIC_CLIENT_ERROR = 2000;
     public static final int STATUS_CODE_INVALID_OR_MISSING_PARAMETERS = 2001;
     public static final int STATUS_CODE_AUTHORIZATION_EXCEPTION_CODE = 2002;
     public static final int STATUS_CODE_NOT_ENOUGH_INFORMATION = 2002;

--- a/src/test/java/com/banula/openlib/ocpi/platform/PlatformClientOcpiComplianceTest.java
+++ b/src/test/java/com/banula/openlib/ocpi/platform/PlatformClientOcpiComplianceTest.java
@@ -12,6 +12,7 @@ import jakarta.validation.Validation;
 import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
@@ -205,7 +206,7 @@ public class PlatformClientOcpiComplianceTest {
                 .build());
         dto.setChargingPeriods(List.of());
         dto.setTotalCost(new Price(0.0f));
-        dto.setTotalEnergy(1.0f);
+        dto.setTotalEnergy(BigDecimal.valueOf(1.0));
         dto.setTotalTime(0.5f);
         dto.setLastUpdated(LocalDateTime.now(ZoneOffset.UTC));
         try {


### PR DESCRIPTION
…lds from Float to BigDecimal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

- Updated the Maven version from `1.1.6` to `1.1.7`.
- Changed `totalEnergy` from `Float` to `BigDecimal` in `CDR` and `CdrDTO`.
- Changed `CdrDimension.volume` and `setVolume` to use `BigDecimal`.
- Added `SmartLocationState.ACTIVE`.
- Added `Constants.STATUS_CODE_GENERIC_CLIENT_ERROR` with value `2000`.
- Updated compliance tests to use `BigDecimal` for `totalEnergy`.

## Aditional info from review-info MCP

| Field | Value |
|-------|-------|
| **Found** | ✅ `true` |
| **Repository** | `banula-cdr-adapter` |
| **Project** | **Transit** (`transit`) |

### Repository Description

Java service processing Charge Detail Records (CDRs). Transforms raw charging session data into standardized CDR format for billing and roaming networks. Implements OCPI 2.2.1 CDR module. Uses MongoDB.

## Project Description

The **Transit** project is an EV charging and roaming platform implementing **OCPI 2.2.1** and **OCPP 1.6** protocols.

It consists of a distributed microservices architecture supporting:

- CPO/eMSP operations
- Billing
- Tariff management
- Roaming through the OCN node
- Admin dashboards

<!-- end of auto-generated comment: release notes by coderabbit.ai -->