### PR TITLE
Chore/olisys 4249/price component big decimal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>energy.oli</groupId>
     <artifactId>banula-open-library</artifactId>
-    <version>1.1.8</version>
+    <version>1.1.9</version>
     <packaging>jar</packaging>
 
     <name>banula-open-library</name>

--- a/src/main/java/com/banula/openlib/ocpi/model/vo/Price.java
+++ b/src/main/java/com/banula/openlib/ocpi/model/vo/Price.java
@@ -1,5 +1,7 @@
 package com.banula.openlib.ocpi.model.vo;
 
+import java.math.BigDecimal;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -15,11 +17,11 @@ import lombok.ToString;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Price {
 
-    public Price(float exclVat) {
+    public Price(BigDecimal exclVat) {
         this.exclVat = exclVat;
     }
 
-    public Price(float exclVat, float inclVat) {
+    public Price(BigDecimal exclVat, BigDecimal inclVat) {
         this.exclVat = exclVat;
         this.inclVat = inclVat;
     }
@@ -30,13 +32,13 @@ public class Price {
     @Digits(integer = Integer.MAX_VALUE, fraction = 4, message = "Invalid price format for exclVat.")
     @NotNull(message = "ExclVat cannot be null.")
     @JsonProperty("excl_vat")
-    private Float exclVat;
+    private BigDecimal exclVat;
 
     /**
      * Price/Cost including VAT.
      */
     @Digits(integer = Integer.MAX_VALUE, fraction = 4, message = "Invalid price format for inclVat.")
     @JsonProperty("incl_vat")
-    private Float inclVat;
+    private BigDecimal inclVat;
 
 }

--- a/src/main/java/com/banula/openlib/ocpi/model/vo/PriceComponent.java
+++ b/src/main/java/com/banula/openlib/ocpi/model/vo/PriceComponent.java
@@ -1,5 +1,7 @@
 package com.banula.openlib.ocpi.model.vo;
 
+import java.math.BigDecimal;
+
 import com.banula.openlib.ocpi.model.enums.TariffDimensionType;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -29,7 +31,7 @@ public class PriceComponent {
     @Digits(integer = Integer.MAX_VALUE, fraction = 4)
     @NotNull
     @JsonProperty("price")
-    private Float price;
+    private BigDecimal price;
 
     /**
      * Applicable VAT percentage for this tariff dimension. If omitted, no VAT is
@@ -39,7 +41,7 @@ public class PriceComponent {
      */
     @Digits(integer = Integer.MAX_VALUE, fraction = 4)
     @JsonProperty("vat")
-    private Float vat;
+    private BigDecimal vat;
 
     /**
      * Minimum amount to be billed. This unit will be billed in this step_size
@@ -54,13 +56,13 @@ public class PriceComponent {
     @JsonProperty("step_size")
     private Integer stepSize;
 
-    public PriceComponent(TariffDimensionType type, Float price, Integer stepSize) {
+    public PriceComponent(TariffDimensionType type, BigDecimal price, Integer stepSize) {
         this.type = type;
         this.price = price;
         this.stepSize = stepSize;
     }
 
-    public PriceComponent(TariffDimensionType type, Float price, Integer stepSize, Float vat) {
+    public PriceComponent(TariffDimensionType type, BigDecimal price, Integer stepSize, BigDecimal vat) {
         this.type = type;
         this.price = price;
         this.stepSize = stepSize;

--- a/src/test/java/com/banula/openlib/ocpi/platform/PlatformClientOcpiComplianceTest.java
+++ b/src/test/java/com/banula/openlib/ocpi/platform/PlatformClientOcpiComplianceTest.java
@@ -152,7 +152,7 @@ public class PlatformClientOcpiComplianceTest {
         TariffDTO dto = new TariffDTO();
         dto.setCurrency("EUR");
         dto.setElements(List.of(new TariffElement(
-                List.of(new PriceComponent(TariffDimensionType.FLAT, 0.5f, 1)))));
+                List.of(new PriceComponent(TariffDimensionType.FLAT, new BigDecimal("0.5"), 1)))));
         EnergyMix energyMix = new EnergyMix(true);
         dto.setEnergyMix(energyMix);
         dto.setLastUpdated(LocalDateTime.now(ZoneOffset.UTC));

--- a/src/test/java/com/banula/openlib/ocpi/platform/PlatformClientOcpiComplianceTest.java
+++ b/src/test/java/com/banula/openlib/ocpi/platform/PlatformClientOcpiComplianceTest.java
@@ -205,7 +205,7 @@ public class PlatformClientOcpiComplianceTest {
                 .connectorPowerType(PowerType.AC_1_PHASE)
                 .build());
         dto.setChargingPeriods(List.of());
-        dto.setTotalCost(new Price(0.0f));
+        dto.setTotalCost(new Price(BigDecimal.ZERO));
         dto.setTotalEnergy(BigDecimal.valueOf(1.0));
         dto.setTotalTime(0.5f);
         dto.setLastUpdated(LocalDateTime.now(ZoneOffset.UTC));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated `PriceComponent.price` and `PriceComponent.vat` from `Float` to `BigDecimal`.
- Updated both `PriceComponent` constructors to accept `BigDecimal` values.
- Updated `Price` VAT-exclusive and VAT-inclusive fields and constructors to use `BigDecimal`.
- Updated the tariff compliance test to use `BigDecimal`.
- Incremented the Maven project version from `1.1.8` to `1.1.9`.

## Aditional info from review-info MCP

| Field | Value |
|-------|-------|
| **Found** | ✅ `true` |
| **Repository** | `banula-open-library` |
| **Project** | **Transit** (`transit`) |

### Repository Description

Java library used as a base dependency for Banula services.

## Project Description

The **Transit** project is an EV charging and roaming platform that implements **OCPI 2.2.1** and **OCPP 1.6**. It supports CPO/eMSP operations, billing, tariff management, roaming through the OCN node, and administration dashboards.

### Project Review Instructions

- Verify OCPI 2.2.1-d2 and OCPP 1.6 compliance.
- Verify library dependency version compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->