### PR TITLE
OLISYS-4939 -> develop | Use BigDecimal for monetary fields and bump version to 1.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>energy.oli</groupId>
     <artifactId>banula-open-library</artifactId>
-    <version>1.1.8</version>
+    <version>1.1.9</version>
     <packaging>jar</packaging>
 
     <name>banula-open-library</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>energy.oli</groupId>
     <artifactId>banula-open-library</artifactId>
-    <version>1.2.0</version>
+    <version>1.2.1</version>
     <packaging>jar</packaging>
 
     <name>banula-open-library</name>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>energy.oli</groupId>
     <artifactId>banula-open-library</artifactId>
-    <version>1.1.9</version>
+    <version>1.2.0</version>
     <packaging>jar</packaging>
 
     <name>banula-open-library</name>

--- a/src/main/java/com/banula/openlib/mongodb/config/MongoConfig.java
+++ b/src/main/java/com/banula/openlib/mongodb/config/MongoConfig.java
@@ -12,6 +12,7 @@ import org.springframework.data.mongodb.core.convert.MappingMongoConverter;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 import org.springframework.data.mongodb.core.mapping.MongoMappingContext;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.Date;
@@ -36,7 +37,9 @@ public class MongoConfig {
     public MongoCustomConversions customConversions() {
         return new MongoCustomConversions(List.of(
                 new LocalDateTimeToDateConverter(),
-                new DateToLocalDateTimeConverter()));
+                new DateToLocalDateTimeConverter(),
+                new LocalDateToDateConverter(),
+                new DateToLocalDateConverter()));
     }
 
     /**
@@ -95,6 +98,33 @@ public class MongoConfig {
         @Override
         public LocalDateTime convert(Date source) {
             return LocalDateTime.ofInstant(source.toInstant(), ZoneOffset.UTC);
+        }
+    }
+
+    /**
+     * Converts LocalDate to Date by pinning it to midnight UTC.
+     *
+     * <p>
+     * Without this converter Spring Data falls back to {@code Jsr310Converters},
+     * which pins to {@link java.time.ZoneId#systemDefault()}: a JVM running on
+     * Europe/Berlin would store {@code 2026-08-24} as {@code 2026-08-23T22:00:00Z}
+     * and any UTC reader would read the day back as {@code 2026-08-23}.
+     */
+    static class LocalDateToDateConverter implements Converter<LocalDate, Date> {
+        @Override
+        public Date convert(LocalDate source) {
+            return Date.from(source.atStartOfDay(ZoneOffset.UTC).toInstant());
+        }
+    }
+
+    /**
+     * Converts Date to LocalDate using UTC, mirroring
+     * {@link LocalDateToDateConverter}.
+     */
+    static class DateToLocalDateConverter implements Converter<Date, LocalDate> {
+        @Override
+        public LocalDate convert(Date source) {
+            return LocalDate.ofInstant(source.toInstant(), ZoneOffset.UTC);
         }
     }
 }

--- a/src/main/java/com/banula/openlib/ocpi/custom/smartlocations/SmartLocation.java
+++ b/src/main/java/com/banula/openlib/ocpi/custom/smartlocations/SmartLocation.java
@@ -1,7 +1,13 @@
 package com.banula.openlib.ocpi.custom.smartlocations;
 
 import com.banula.openlib.ocpi.model.Location;
+import com.banula.openlib.ocpi.util.OCPILocalDateDeserializer;
+import com.banula.openlib.ocpi.util.OCPILocalDateSerializer;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import java.time.LocalDate;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -47,4 +53,14 @@ public class SmartLocation extends Location {
 
     @JsonProperty("smart_location_state")
     private SmartLocationState smartLocationState;
+
+    @JsonProperty("active_first_day")
+    @JsonSerialize(using = OCPILocalDateSerializer.class)
+    @JsonDeserialize(using = OCPILocalDateDeserializer.class)
+    private LocalDate activeFirstDay;
+
+    @JsonProperty("active_last_day")
+    @JsonSerialize(using = OCPILocalDateSerializer.class)
+    @JsonDeserialize(using = OCPILocalDateDeserializer.class)
+    private LocalDate activeLastDay;
 }

--- a/src/main/java/com/banula/openlib/ocpi/custom/smartlocations/dto/SmartLocationDTO.java
+++ b/src/main/java/com/banula/openlib/ocpi/custom/smartlocations/dto/SmartLocationDTO.java
@@ -5,7 +5,13 @@ import com.banula.openlib.ocpi.custom.smartlocations.MeteringDataSource;
 import com.banula.openlib.ocpi.custom.smartlocations.SmartLocationState;
 import com.banula.openlib.ocpi.custom.smartlocations.validations.SmartLocationCreateGroup;
 import com.banula.openlib.ocpi.model.dto.LocationDTO;
+import com.banula.openlib.ocpi.util.OCPILocalDateDeserializer;
+import com.banula.openlib.ocpi.util.OCPILocalDateSerializer;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+
+import java.time.LocalDate;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotEmpty;
@@ -63,4 +69,14 @@ public class SmartLocationDTO extends LocationDTO {
 
     @JsonProperty("smart_location_state")
     private SmartLocationState smartLocationState;
+
+    @JsonProperty("active_first_day")
+    @JsonSerialize(using = OCPILocalDateSerializer.class)
+    @JsonDeserialize(using = OCPILocalDateDeserializer.class)
+    private LocalDate activeFirstDay;
+
+    @JsonProperty("active_last_day")
+    @JsonSerialize(using = OCPILocalDateSerializer.class)
+    @JsonDeserialize(using = OCPILocalDateDeserializer.class)
+    private LocalDate activeLastDay;
 }

--- a/src/main/java/com/banula/openlib/ocpi/custom/smartlocations/util/SmartLocationActivationUtil.java
+++ b/src/main/java/com/banula/openlib/ocpi/custom/smartlocations/util/SmartLocationActivationUtil.java
@@ -1,0 +1,144 @@
+package com.banula.openlib.ocpi.custom.smartlocations.util;
+
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+import com.banula.openlib.ocpi.custom.smartlocations.SmartLocation;
+import com.banula.openlib.ocpi.custom.smartlocations.SmartLocationState;
+
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Decides whether a {@link SmartLocation} is currently inside its activation
+ * window, and which {@link SmartLocationState} follows from that.
+ *
+ * <p>
+ * This is the single implementation shared by every service that evaluates
+ * activation windows (banula-nsp and banula-cdr-adapter today). Both must reach
+ * bit-identical answers, otherwise the cdr-adapter mirror desynchronises from
+ * the NSP source of truth.
+ *
+ * <p>
+ * The evaluation is <b>idempotent</b> (running it twice changes nothing) and
+ * <b>reversible</b> (a window moved into the past demotes the location again),
+ * which is what makes an on-demand refresh endpoint safe.
+ */
+@Slf4j
+public class SmartLocationActivationUtil {
+
+    /** Fallback zone: activation windows are defined in German calendar days. */
+    public static final String DEFAULT_ZONE_ID = "Europe/Berlin";
+
+    private SmartLocationActivationUtil() {
+    }
+
+    /**
+     * Today's calendar day in the given zone, falling back to
+     * {@link #DEFAULT_ZONE_ID} when the zone is blank or unknown.
+     */
+    public static LocalDate today(String zoneId) {
+        return LocalDate.now(resolveZone(zoneId));
+    }
+
+    private static ZoneId resolveZone(String zoneId) {
+        if (zoneId == null || zoneId.isBlank()) {
+            return ZoneId.of(DEFAULT_ZONE_ID);
+        }
+        try {
+            return ZoneId.of(zoneId.trim());
+        } catch (DateTimeException e) {
+            log.warn("Unknown zone id '{}' for smart location activation, falling back to {}", zoneId,
+                    DEFAULT_ZONE_ID);
+            return ZoneId.of(DEFAULT_ZONE_ID);
+        }
+    }
+
+    /**
+     * A location has an activation window only when <b>both</b> edge days are set;
+     * a single day on its own does nothing.
+     */
+    public static boolean hasActivationWindow(SmartLocation location) {
+        return location != null && location.getActiveFirstDay() != null && location.getActiveLastDay() != null;
+    }
+
+    /** A window is valid when its first day is not after its last day. */
+    public static boolean isWindowValid(SmartLocation location) {
+        return hasActivationWindow(location)
+                && !location.getActiveFirstDay().isAfter(location.getActiveLastDay());
+    }
+
+    /**
+     * Whether {@code today} falls inside the location's activation window, with
+     * <b>both edge days inclusive</b>. An inverted window never activates and is
+     * logged so that bad data stays visible.
+     */
+    public static boolean isWithinActiveWindow(SmartLocation location, LocalDate today) {
+        if (!hasActivationWindow(location) || today == null) {
+            return false;
+        }
+        if (!isWindowValid(location)) {
+            log.warn("Smart location {} has an inverted activation window ({} > {}); it will never activate",
+                    location.getId(), location.getActiveFirstDay(), location.getActiveLastDay());
+            return false;
+        }
+        return !today.isBefore(location.getActiveFirstDay()) && !today.isAfter(location.getActiveLastDay());
+    }
+
+    /**
+     * The state the location should have today.
+     *
+     * <p>
+     * Only {@code VERIFIED} and {@code ACTIVE} ever move, and only into each
+     * other. {@code PLAIN_OCPI}, {@code ENRICHED}, {@code INVALID} and
+     * {@code ARCHIVED} are manual decisions and always win.
+     */
+    public static SmartLocationState resolveState(SmartLocation location, LocalDate today) {
+        if (location == null) {
+            return null;
+        }
+
+        SmartLocationState current = location.getSmartLocationState();
+        if (current != SmartLocationState.VERIFIED && current != SmartLocationState.ACTIVE) {
+            return current;
+        }
+
+        return isWithinActiveWindow(location, today)
+                ? SmartLocationState.ACTIVE
+                : SmartLocationState.VERIFIED;
+    }
+
+    /**
+     * Applies {@link #resolveState(SmartLocation, LocalDate)} to the location.
+     *
+     * @return {@code true} only when the state actually changed, so callers can
+     *         skip the write — and therefore avoid bumping {@code lastUpdated},
+     *         the cursor OCPI clients page on.
+     */
+    public static boolean applyActiveState(SmartLocation location, LocalDate today) {
+        if (location == null) {
+            return false;
+        }
+
+        SmartLocationState resolved = resolveState(location, today);
+        if (resolved == location.getSmartLocationState()) {
+            return false;
+        }
+
+        log.info("Smart location {} moves from {} to {} (window {} .. {}, today {})", location.getId(),
+                location.getSmartLocationState(), resolved, location.getActiveFirstDay(),
+                location.getActiveLastDay(), today);
+        location.setSmartLocationState(resolved);
+        return true;
+    }
+
+    /**
+     * The single answer to "may this location be served to other parties?" — used
+     * by the {@code publish} flag and by every sender endpoint, so a future policy
+     * change is one edit.
+     */
+    public static boolean isPubliclyServable(SmartLocationState state) {
+        return state == SmartLocationState.ACTIVE;
+    }
+
+}

--- a/src/main/java/com/banula/openlib/ocpi/model/vo/Price.java
+++ b/src/main/java/com/banula/openlib/ocpi/model/vo/Price.java
@@ -1,5 +1,7 @@
 package com.banula.openlib.ocpi.model.vo;
 
+import java.math.BigDecimal;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
@@ -15,11 +17,11 @@ import lombok.ToString;
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class Price {
 
-    public Price(float exclVat) {
+    public Price(BigDecimal exclVat) {
         this.exclVat = exclVat;
     }
 
-    public Price(float exclVat, float inclVat) {
+    public Price(BigDecimal exclVat, BigDecimal inclVat) {
         this.exclVat = exclVat;
         this.inclVat = inclVat;
     }
@@ -30,13 +32,13 @@ public class Price {
     @Digits(integer = Integer.MAX_VALUE, fraction = 4, message = "Invalid price format for exclVat.")
     @NotNull(message = "ExclVat cannot be null.")
     @JsonProperty("excl_vat")
-    private Float exclVat;
+    private BigDecimal exclVat;
 
     /**
      * Price/Cost including VAT.
      */
     @Digits(integer = Integer.MAX_VALUE, fraction = 4, message = "Invalid price format for inclVat.")
     @JsonProperty("incl_vat")
-    private Float inclVat;
+    private BigDecimal inclVat;
 
 }

--- a/src/main/java/com/banula/openlib/ocpi/model/vo/PriceComponent.java
+++ b/src/main/java/com/banula/openlib/ocpi/model/vo/PriceComponent.java
@@ -1,5 +1,7 @@
 package com.banula.openlib.ocpi.model.vo;
 
+import java.math.BigDecimal;
+
 import com.banula.openlib.ocpi.model.enums.TariffDimensionType;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -29,7 +31,7 @@ public class PriceComponent {
     @Digits(integer = Integer.MAX_VALUE, fraction = 4)
     @NotNull
     @JsonProperty("price")
-    private Float price;
+    private BigDecimal price;
 
     /**
      * Applicable VAT percentage for this tariff dimension. If omitted, no VAT is
@@ -39,7 +41,7 @@ public class PriceComponent {
      */
     @Digits(integer = Integer.MAX_VALUE, fraction = 4)
     @JsonProperty("vat")
-    private Float vat;
+    private BigDecimal vat;
 
     /**
      * Minimum amount to be billed. This unit will be billed in this step_size
@@ -54,13 +56,13 @@ public class PriceComponent {
     @JsonProperty("step_size")
     private Integer stepSize;
 
-    public PriceComponent(TariffDimensionType type, Float price, Integer stepSize) {
+    public PriceComponent(TariffDimensionType type, BigDecimal price, Integer stepSize) {
         this.type = type;
         this.price = price;
         this.stepSize = stepSize;
     }
 
-    public PriceComponent(TariffDimensionType type, Float price, Integer stepSize, Float vat) {
+    public PriceComponent(TariffDimensionType type, BigDecimal price, Integer stepSize, BigDecimal vat) {
         this.type = type;
         this.price = price;
         this.stepSize = stepSize;

--- a/src/main/java/com/banula/openlib/ocpi/util/OCPILocalDateDeserializer.java
+++ b/src/main/java/com/banula/openlib/ocpi/util/OCPILocalDateDeserializer.java
@@ -1,0 +1,44 @@
+package com.banula.openlib.ocpi.util;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeParseException;
+
+/**
+ * Deserializes a plain ISO calendar day ({@code yyyy-MM-dd}), tolerating a full
+ * ISO date-time by keeping only its date part.
+ */
+@Slf4j
+public class OCPILocalDateDeserializer extends JsonDeserializer<LocalDate> {
+
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
+
+    @Override
+    public LocalDate deserialize(JsonParser p, DeserializationContext ctxt) throws IOException {
+        String raw = p.getText().trim();
+
+        try {
+            return LocalDate.parse(raw, DATE_FORMATTER);
+        } catch (DateTimeParseException ignored) {
+        }
+
+        // Tolerate a full date-time payload by keeping only the calendar day.
+        int separator = raw.indexOf('T');
+        if (separator > 0) {
+            try {
+                return LocalDate.parse(raw.substring(0, separator), DATE_FORMATTER);
+            } catch (DateTimeParseException ignored) {
+            }
+        }
+
+        log.error("Invalid OCPI date format: " + raw);
+        throw new IOException("Invalid OCPI date format: " + raw);
+    }
+
+}

--- a/src/main/java/com/banula/openlib/ocpi/util/OCPILocalDateSerializer.java
+++ b/src/main/java/com/banula/openlib/ocpi/util/OCPILocalDateSerializer.java
@@ -1,0 +1,29 @@
+package com.banula.openlib.ocpi.util;
+
+import java.io.IOException;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.databind.JsonSerializer;
+import com.fasterxml.jackson.databind.SerializerProvider;
+
+/**
+ * Serializes a {@link LocalDate} as a plain ISO calendar day ({@code yyyy-MM-dd}).
+ *
+ * <p>
+ * Declared explicitly on every {@link LocalDate} field (never via
+ * {@code @JsonFormat}) because this library is consumed by services that
+ * configure their own {@code ObjectMapper}.
+ */
+public class OCPILocalDateSerializer extends JsonSerializer<LocalDate> {
+
+    private static final DateTimeFormatter FORMATTER = DateTimeFormatter.ISO_LOCAL_DATE;
+
+    @Override
+    public void serialize(LocalDate value, JsonGenerator gen, SerializerProvider serializers)
+            throws IOException {
+        gen.writeString(value.format(FORMATTER));
+    }
+
+}

--- a/src/test/java/com/banula/openlib/ocpi/custom/smartlocations/util/SmartLocationActivationUtilTest.java
+++ b/src/test/java/com/banula/openlib/ocpi/custom/smartlocations/util/SmartLocationActivationUtilTest.java
@@ -1,0 +1,197 @@
+package com.banula.openlib.ocpi.custom.smartlocations.util;
+
+import com.banula.openlib.ocpi.custom.smartlocations.SmartLocation;
+import com.banula.openlib.ocpi.custom.smartlocations.SmartLocationState;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class SmartLocationActivationUtilTest {
+
+    private static final LocalDate TODAY = LocalDate.of(2026, 8, 24);
+
+    @Test
+    void today_shouldFallBackToBerlin_whenZoneIdIsBlankOrUnknown() {
+        LocalDate berlin = LocalDate.now(java.time.ZoneId.of("Europe/Berlin"));
+
+        assertEquals(berlin, SmartLocationActivationUtil.today(null));
+        assertEquals(berlin, SmartLocationActivationUtil.today("  "));
+        assertEquals(berlin, SmartLocationActivationUtil.today("Not/AZone"));
+    }
+
+    @Test
+    void today_shouldUseGivenZone_whenZoneIdIsValid() {
+        assertEquals(LocalDate.now(java.time.ZoneId.of("UTC")), SmartLocationActivationUtil.today("UTC"));
+    }
+
+    @Test
+    void hasActivationWindow_shouldRequireBothDays() {
+        assertFalse(SmartLocationActivationUtil.hasActivationWindow(window(null, null)));
+        assertFalse(SmartLocationActivationUtil.hasActivationWindow(window(TODAY, null)));
+        assertFalse(SmartLocationActivationUtil.hasActivationWindow(window(null, TODAY)));
+        assertTrue(SmartLocationActivationUtil.hasActivationWindow(window(TODAY, TODAY)));
+        assertFalse(SmartLocationActivationUtil.hasActivationWindow(null));
+    }
+
+    @Test
+    void isWindowValid_shouldRejectInvertedWindow() {
+        assertTrue(SmartLocationActivationUtil.isWindowValid(window(TODAY.minusDays(1), TODAY)));
+        assertTrue(SmartLocationActivationUtil.isWindowValid(window(TODAY, TODAY)));
+        assertFalse(SmartLocationActivationUtil.isWindowValid(window(TODAY, TODAY.minusDays(1))));
+    }
+
+    @Test
+    void isWithinActiveWindow_shouldIncludeBothEdgeDays() {
+        SmartLocation location = window(TODAY.minusDays(1), TODAY.plusDays(1));
+
+        assertTrue(SmartLocationActivationUtil.isWithinActiveWindow(location, TODAY.minusDays(1)));
+        assertTrue(SmartLocationActivationUtil.isWithinActiveWindow(location, TODAY));
+        assertTrue(SmartLocationActivationUtil.isWithinActiveWindow(location, TODAY.plusDays(1)));
+    }
+
+    @Test
+    void isWithinActiveWindow_shouldExcludeDayBeforeAndDayAfter() {
+        SmartLocation location = window(TODAY.minusDays(1), TODAY.plusDays(1));
+
+        assertFalse(SmartLocationActivationUtil.isWithinActiveWindow(location, TODAY.minusDays(2)));
+        assertFalse(SmartLocationActivationUtil.isWithinActiveWindow(location, TODAY.plusDays(2)));
+    }
+
+    @Test
+    void isWithinActiveWindow_shouldAcceptOneDayWindow() {
+        assertTrue(SmartLocationActivationUtil.isWithinActiveWindow(window(TODAY, TODAY), TODAY));
+        assertFalse(SmartLocationActivationUtil.isWithinActiveWindow(window(TODAY, TODAY), TODAY.plusDays(1)));
+    }
+
+    @Test
+    void isWithinActiveWindow_shouldReturnFalse_whenOnlyOneDayIsSet() {
+        assertFalse(SmartLocationActivationUtil.isWithinActiveWindow(window(TODAY, null), TODAY));
+        assertFalse(SmartLocationActivationUtil.isWithinActiveWindow(window(null, TODAY), TODAY));
+    }
+
+    @Test
+    void isWithinActiveWindow_shouldReturnFalse_whenWindowIsInverted() {
+        assertFalse(SmartLocationActivationUtil.isWithinActiveWindow(window(TODAY.plusDays(1), TODAY.minusDays(1)),
+                TODAY));
+    }
+
+    @Test
+    void isWithinActiveWindow_shouldReturnFalse_whenTodayIsNull() {
+        assertFalse(SmartLocationActivationUtil.isWithinActiveWindow(window(TODAY, TODAY), null));
+    }
+
+    @Test
+    void resolveState_shouldPromoteVerifiedInsideWindow() {
+        SmartLocation location = window(TODAY, TODAY, SmartLocationState.VERIFIED);
+
+        assertEquals(SmartLocationState.ACTIVE, SmartLocationActivationUtil.resolveState(location, TODAY));
+    }
+
+    @Test
+    void resolveState_shouldKeepVerifiedOutsideWindow() {
+        SmartLocation location = window(TODAY.minusDays(10), TODAY.minusDays(5), SmartLocationState.VERIFIED);
+
+        assertEquals(SmartLocationState.VERIFIED, SmartLocationActivationUtil.resolveState(location, TODAY));
+    }
+
+    @Test
+    void resolveState_shouldKeepActiveInsideWindow() {
+        SmartLocation location = window(TODAY.minusDays(1), TODAY.plusDays(1), SmartLocationState.ACTIVE);
+
+        assertEquals(SmartLocationState.ACTIVE, SmartLocationActivationUtil.resolveState(location, TODAY));
+    }
+
+    @Test
+    void resolveState_shouldDemoteActiveOutsideWindow() {
+        SmartLocation location = window(TODAY.minusDays(10), TODAY.minusDays(5), SmartLocationState.ACTIVE);
+
+        assertEquals(SmartLocationState.VERIFIED, SmartLocationActivationUtil.resolveState(location, TODAY));
+    }
+
+    @Test
+    void resolveState_shouldDemoteActive_whenWindowIsRemoved() {
+        SmartLocation location = window(null, null, SmartLocationState.ACTIVE);
+
+        assertEquals(SmartLocationState.VERIFIED, SmartLocationActivationUtil.resolveState(location, TODAY));
+    }
+
+    @Test
+    void resolveState_shouldNeverTouchManualStates() {
+        List<SmartLocationState> manualStates = List.of(SmartLocationState.PLAIN_OCPI, SmartLocationState.ENRICHED,
+                SmartLocationState.INVALID, SmartLocationState.ARCHIVED);
+
+        for (SmartLocationState state : manualStates) {
+            assertEquals(state, SmartLocationActivationUtil.resolveState(window(TODAY, TODAY, state), TODAY),
+                    "in-window " + state);
+            assertEquals(state,
+                    SmartLocationActivationUtil.resolveState(window(TODAY.minusDays(9), TODAY.minusDays(8), state),
+                            TODAY),
+                    "out-of-window " + state);
+        }
+    }
+
+    @Test
+    void resolveState_shouldKeepNullState() {
+        assertNull(SmartLocationActivationUtil.resolveState(window(TODAY, TODAY, null), TODAY));
+        assertNull(SmartLocationActivationUtil.resolveState(null, TODAY));
+    }
+
+    @Test
+    void applyActiveState_shouldReportChange_onlyOnTheFirstRun() {
+        SmartLocation location = window(TODAY, TODAY, SmartLocationState.VERIFIED);
+
+        assertTrue(SmartLocationActivationUtil.applyActiveState(location, TODAY));
+        assertEquals(SmartLocationState.ACTIVE, location.getSmartLocationState());
+
+        assertFalse(SmartLocationActivationUtil.applyActiveState(location, TODAY));
+        assertEquals(SmartLocationState.ACTIVE, location.getSmartLocationState());
+    }
+
+    @Test
+    void applyActiveState_shouldBeReversible() {
+        SmartLocation location = window(TODAY, TODAY, SmartLocationState.VERIFIED);
+
+        assertTrue(SmartLocationActivationUtil.applyActiveState(location, TODAY));
+        assertTrue(SmartLocationActivationUtil.applyActiveState(location, TODAY.plusDays(1)));
+        assertEquals(SmartLocationState.VERIFIED, location.getSmartLocationState());
+        assertFalse(SmartLocationActivationUtil.applyActiveState(location, TODAY.plusDays(1)));
+    }
+
+    @Test
+    void applyActiveState_shouldReturnFalse_whenLocationIsNull() {
+        assertFalse(SmartLocationActivationUtil.applyActiveState(null, TODAY));
+    }
+
+    @Test
+    void isPubliclyServable_shouldOnlyAcceptActive() {
+        assertTrue(SmartLocationActivationUtil.isPubliclyServable(SmartLocationState.ACTIVE));
+        assertFalse(SmartLocationActivationUtil.isPubliclyServable(SmartLocationState.VERIFIED));
+        assertFalse(SmartLocationActivationUtil.isPubliclyServable(null));
+        for (SmartLocationState state : SmartLocationState.values()) {
+            assertEquals(state == SmartLocationState.ACTIVE, SmartLocationActivationUtil.isPubliclyServable(state));
+        }
+        assertNotNull(SmartLocationState.ACTIVE);
+    }
+
+    private SmartLocation window(LocalDate first, LocalDate last) {
+        return window(first, last, SmartLocationState.VERIFIED);
+    }
+
+    private SmartLocation window(LocalDate first, LocalDate last, SmartLocationState state) {
+        SmartLocation location = new SmartLocation();
+        location.setCountryCode("DE");
+        location.setPartyId("ABC");
+        location.setId("LOCTEST");
+        location.setSmartLocationState(state);
+        location.setActiveFirstDay(first);
+        location.setActiveLastDay(last);
+        return location;
+    }
+}

--- a/src/test/java/com/banula/openlib/ocpi/platform/PlatformClientOcpiComplianceTest.java
+++ b/src/test/java/com/banula/openlib/ocpi/platform/PlatformClientOcpiComplianceTest.java
@@ -152,7 +152,7 @@ public class PlatformClientOcpiComplianceTest {
         TariffDTO dto = new TariffDTO();
         dto.setCurrency("EUR");
         dto.setElements(List.of(new TariffElement(
-                List.of(new PriceComponent(TariffDimensionType.FLAT, 0.5f, 1)))));
+                List.of(new PriceComponent(TariffDimensionType.FLAT, new BigDecimal("0.5"), 1)))));
         EnergyMix energyMix = new EnergyMix(true);
         dto.setEnergyMix(energyMix);
         dto.setLastUpdated(LocalDateTime.now(ZoneOffset.UTC));

--- a/src/test/java/com/banula/openlib/ocpi/platform/PlatformClientOcpiComplianceTest.java
+++ b/src/test/java/com/banula/openlib/ocpi/platform/PlatformClientOcpiComplianceTest.java
@@ -205,7 +205,7 @@ public class PlatformClientOcpiComplianceTest {
                 .connectorPowerType(PowerType.AC_1_PHASE)
                 .build());
         dto.setChargingPeriods(List.of());
-        dto.setTotalCost(new Price(0.0f));
+        dto.setTotalCost(new Price(BigDecimal.ZERO));
         dto.setTotalEnergy(BigDecimal.valueOf(1.0));
         dto.setTotalTime(0.5f);
         dto.setLastUpdated(LocalDateTime.now(ZoneOffset.UTC));

--- a/src/test/java/com/banula/openlib/ocpi/util/ModelPatcherUtilTest.java
+++ b/src/test/java/com/banula/openlib/ocpi/util/ModelPatcherUtilTest.java
@@ -6,6 +6,7 @@ import com.banula.openlib.ocpi.custom.smartlocations.SmartLocation;
 import com.banula.openlib.ocpi.model.Location;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDate;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -21,6 +22,8 @@ class ModelPatcherUtilTest {
         incomplete.setMalo("NEW_MALO");
         incomplete.setSmartMeterId("NEW_SMART_METER");
         incomplete.setMeteringDataSource(MeteringDataSource.CONTROL_BACKEND);
+        incomplete.setActiveFirstDay(LocalDate.of(2026, 8, 24));
+        incomplete.setActiveLastDay(LocalDate.of(2026, 8, 26));
         incomplete.setDefaultSupplier(DefaultSupplier.builder()
                 .supplierMarketPartnerId("SUPPLIER")
                 .bkvId("BKV")
@@ -35,6 +38,24 @@ class ModelPatcherUtilTest {
         assertEquals("NEW_SMART_METER", existing.getSmartMeterId());
         assertEquals(MeteringDataSource.CONTROL_BACKEND, existing.getMeteringDataSource());
         assertEquals("SUPPLIER", existing.getDefaultSupplier().getSupplierMarketPartnerId());
+        assertEquals(LocalDate.of(2026, 8, 24), existing.getActiveFirstDay());
+        assertEquals(LocalDate.of(2026, 8, 26), existing.getActiveLastDay());
+    }
+
+    @Test
+    void smartLocationPatcher_cannotClearActivationWindow() throws IllegalAccessException {
+        SmartLocation existing = buildSmartLocation(false, "MALO", "SMART_METER");
+        existing.setActiveFirstDay(LocalDate.of(2026, 8, 24));
+        existing.setActiveLastDay(LocalDate.of(2026, 8, 26));
+
+        SmartLocation incomplete = new SmartLocation();
+        incomplete.setMalo("OTHER_MALO");
+
+        ModelPatcherUtil.smartLocationPatcher(existing, incomplete);
+
+        // The patcher copies non-null values only, so nulls never clear a field.
+        assertEquals(LocalDate.of(2026, 8, 24), existing.getActiveFirstDay());
+        assertEquals(LocalDate.of(2026, 8, 26), existing.getActiveLastDay());
     }
 
     @Test


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary

- Updated the Maven project version to `1.2.1`.
- Replaced monetary `Float` fields with `BigDecimal` in `Price` and `PriceComponent`.
- Updated public constructors and compliance tests for `BigDecimal` values.
- Added UTC-safe `LocalDate` MongoDB converters.
- Added smart-location activation dates to `SmartLocation` and `SmartLocationDTO`.
- Added OCPI local-date serialization and deserialization.
- Added `SmartLocationActivationUtil` for activation-window validation and state transitions.
- Added tests for activation logic, date patching, and null handling.

## Aditional info from review-info MCP

| Field | Value |
|-------|-------|
| **Found** | ✅ `true` |
| **Repository** | `banula-cdr-adapter` |
| **Project** | **Transit** (`transit`) |

### Repository Description

Java service processing Charge Detail Records (CDRs). Transforms raw charging session data into standardized CDR format for billing and roaming networks. Implements OCPI CDR module. Uses MongoDB.

## Project Description

The **Transit** project is an EV charging and roaming platform implementing **OCPI 2.2.1** and **OCPP 1.6** protocols.

It consists of a distributed microservices architecture supporting:

- CPO/eMSP operations
- Billing
- Tariff management
- Roaming (OCN node)
- Admin dashboards
<!-- end of auto-generated comment: release notes by coderabbit.ai -->